### PR TITLE
changed compile_version in Nargo.toml

### DIFF
--- a/next-hardhat/circuits/Nargo.toml
+++ b/next-hardhat/circuits/Nargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noir-starter"
 authors = [""]
-compiler_version = "0.4.1"
+compiler_version = "0.9.0"
 
 [dependencies]


### PR DESCRIPTION
Perhaps I misunderstand how it's supposed to be used. But should it not be 0.9.0?